### PR TITLE
Added support for messaging_referrals for Facebook

### DIFF
--- a/lib/facebook/facebook-chat.js
+++ b/lib/facebook/facebook-chat.js
@@ -63,7 +63,14 @@ var Facebook = new ChatExpress({
                 event.message = {
                   text: event.postback.payload
                 };
+                event.referral = event.postback.referral ? event.postback.referral: null // for GET_STARTED event
                 delete event.postback;
+                chatServer.receive(event);
+              } else if (event.referral != null) {
+                // handle referrals for existing thread (person spoked to bot before)
+                event.message = {
+                  text: event.referral
+                };
                 chatServer.receive(event);
               } else if (event.account_linking != null) {
                 chatServer.receive(event);
@@ -79,6 +86,16 @@ var Facebook = new ChatExpress({
     '/redbot/facebook': 'Use this in the "Webhooks" section of the Facebook App ("Edit Subscription" button)',
     '/redbot/facebook/test': 'Use this to test that your SSL (with certificate or ngrok) is working properly, should answer "ok"'
   }
+});
+
+// detect referral payload
+Facebook.in(function(message) {
+  if (message.originalMessage.referral != null) {
+    message.payload.type = 'referral';
+    message.payload.content = message.originalMessage.referral;
+    return message;
+  }
+  return message;
 });
 
 // detect account linking payload


### PR DESCRIPTION
Add support to messaging_referrals.

Allows you to pass ref arguments to your bot eg.:  http://m.me/MyBot?ref=superLongReferenceForSomeMagic

Requires a Facebook Messenger Webhook event subscription to:  [messaging_referrals](https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_referrals) 

Example debug from an update to an existing conversation (already open thread)

```{ originalMessage:
   { recipient: { id: '10102' },
     timestamp: 1524456885595,
     sender: { id: '10101' },
     referral: { ref: '<reference id>', source: 'SHORTLINK', type: 'OPEN_THREAD' },
     message: { text: [Object] },
     chatId: '10101',
     userId: '1',
     transport: 'facebook',
     language: undefined },
  payload:
   { type: 'referral',
     chatId: '10101',
     userId: '10101',
     ts: moment("2018-04-23T04:14:45.595"),
     transport: 'facebook',
     inbound: true,
     content: { ref: '<reference id>', source: 'SHORTLINK', type: 'OPEN_THREAD' } },
  chat: [Function: chat],
  api: [Function: api],
  client: [Function: client],
  _msgid: '10101' }
```

Example from a GET STARTED postback payload

```
{ originalMessage:
   { recipient: { id: '10102' },
     timestamp: 1524456715040,
     sender: { id: '10101' },
     message: { text: '/start' },
     referral: { ref: '<SUPER_REFERENCE>', source: 'SHORTLINK', type: 'OPEN_THREAD' },
     chatId: '0110101010',
     userId: '01011010',
     transport: 'facebook',
     language: undefined },
  payload:
   { type: 'message',
     chatId: '0101101010',
     userId: '1010101',
     ts: moment("2018-04-23T04:11:55.040"),
     transport: 'facebook',
     inbound: true,
     content: '/start' },
  chat: [Function: chat],
  api: [Function: api],
  client: [Function: client],
  _msgid: '010101.101010' }
```