### PR TITLE
Added support for Facebook Messaging Optins

### DIFF
--- a/lib/platforms/facebook-chat.js
+++ b/lib/platforms/facebook-chat.js
@@ -78,6 +78,12 @@ var Facebook = new ChatExpress({
                     text: event.referral
                   };
                   chatServer.receive(event);
+                } else if (event.optin != null) {
+                  // handle optin
+                  event.message = {
+                    text: event.optin
+                  };
+                  chatServer.receive(event);
                 } else if (event.account_linking != null) {
                   chatServer.receive(event);
                 }
@@ -103,6 +109,16 @@ Facebook.in(function(message) {
   if (message.originalMessage.referral != null) {
     message.payload.type = 'referral';
     message.payload.content = message.originalMessage.referral;
+    return message;
+  }
+  return message;
+});
+
+// detect optin payload
+Facebook.in(function(message) {
+  if (message.originalMessage.optin != null) {
+    message.payload.type = 'optin';
+    message.payload.content = message.originalMessage.optin;
     return message;
   }
   return message;


### PR DESCRIPTION
A simple addition for allowing messaging optins.

Can be useful in a function node

```
if(msg.originalMessage.optin) {
    node.log(`Setting optin variable to ${msg.originalMessage.optin.ref}`);
    chat.set('optin', msg.originalMessage.optin.ref);
}

```

reference: https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_optins/