### PR TITLE
Added support for "slackExtensions"

### DIFF
--- a/lib/platforms/slack.js
+++ b/lib/platforms/slack.js
@@ -245,8 +245,9 @@ Slack.out('message', function(message) {
   var chatContext = message.chat();
   return new Promise(function(resolve, reject) {
     var client = options.client;
-
-    client.chat.postMessage({ channel: message.payload.chatId, text: message.payload.content })
+    var slackExtensions = message.slackExtensions || {};
+    var payload = Object.assign({ channel: message.payload.chatId, text: message.payload.content }, slackExtensions);
+    client.chat.postMessage(payload)
       .then(function(res) {
         return when(chatContext.set('messageId', res.ts));
       })
@@ -277,12 +278,14 @@ Slack.out('location', function(message) {
         'color': '#7CD197'
       }
     ];
-    client.chat
-      .postMessage({
+    var slackExtensions = message.slackExtensions || {};
+    var payload = Object.assign({
         channel: message.payload.chatId,
         text: '',
         attachments: attachments
-      })
+    }, slackExtensions);
+    client.chat
+      .postMessage(payload)
       .then(
         function() {
           resolve(message);
@@ -422,20 +425,23 @@ Slack.out('inline-buttons', function(message) {
   var chatServer = this;
   return new Promise(function(resolve, reject) {
     var client = options.client;
-    client.chat
-      .postMessage({
+    var slackExtensions = message.slackExtensions || {};
+    var payload = {
         channel: message.payload.chatId,
         text: message.payload.content,
         attachments: [
-          {
-            'text': message.payload.content,
-            callback_id: !_.isEmpty(message.payload.name) ? message.payload.name : _.uniqueId('callback_'),
-            color: '#3AA3E3',
-            attachment_type: 'default',
-            actions: chatServer.parseButtons(message.payload.buttons)
-          }
+            {
+                'text': message.payload.content,
+                callback_id: !_.isEmpty(message.payload.name) ? message.payload.name : _.uniqueId('callback_'),
+                color: '#3AA3E3',
+                attachment_type: 'default',
+                actions: chatServer.parseButtons(message.payload.buttons)
+            }
         ]
-      })
+    };
+    payload = Object.assign(payload, slackExtensions);
+    client.chat
+      .postMessage(payload)
       .then(
         function() {
           resolve(message);
@@ -468,12 +474,16 @@ Slack.out('generic-template', function(message) {
       return attachment;
     });
 
-    client.chat
-      .postMessage({
+    var slackExtensions = message.slackExtensions || {};
+    var payload = {
         channel: message.payload.chatId,
         text: message.payload.content,
         attachments: attachments
-      })
+    };
+    payload = Object.assign(payload, slackExtensions);
+
+    client.chat
+      .postMessage(payload)
       .then(function(res) {
         return when(chatContext.set('messageId', res.ts));
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -2993,6 +2993,7 @@
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -3055,7 +3056,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -3343,12 +3345,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -3424,7 +3428,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -5258,7 +5263,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }


### PR DESCRIPTION
Added support for "slackExtensions" in messages to pass extended attributes to slack api

This way we can do something like this:

![image](https://user-images.githubusercontent.com/578310/49827183-da45ba00-fd6f-11e8-8cd7-8263851476bb.png)

With _test_ node adding the extended attributes:

```javascript
msg.slackExtensions = {
    icon_emoji: ":huehue:",
    username: "Dark Roboto"
}

return msg;
```

And change unmapped properties that are specific to slack:
![image](https://user-images.githubusercontent.com/578310/49827235-fc3f3c80-fd6f-11e8-80d5-a329b756600e.png)
