### PR TITLE
Fixed set command so fieldValue input displays

### DIFF
--- a/nodes/chatbot-context.html
+++ b/nodes/chatbot-context.html
@@ -64,7 +64,7 @@
   <label for="node-input-fieldName">Variable</label>
   <input type="text" id="node-input-fieldName" placeholder="Variable" style="width:250px;">
 </div>
-<div class="form-row only-for only-for-fieldValue">
+<div class="form-row only-for only-for-set">
   <label for="node-input-fieldValue"><i class="icon-pencil"></i> Value</label>
   <input type="text" id="node-input-fieldValue" placeholder="" style="width:250px;">
   <input type="hidden" id="node-input-fieldType">


### PR DESCRIPTION
Fixed a bug with the context config form that prevented the fieldValue input from displaying when selecting the "set" command option.