### PR TITLE
Correctly extract slack event chatIds

### DIFF
--- a/lib/platforms/slack.js
+++ b/lib/platforms/slack.js
@@ -103,9 +103,9 @@ const Slack = new ChatExpress({
       res.send('ok');
     },
     '/redbot/slack': function(req, res) {
-      
 
-      
+
+
 
       let payload;
       if (_.isObject(req.body) && !_.isEmpty(req.body.type)) {
@@ -118,7 +118,7 @@ const Slack = new ChatExpress({
         res.sendStatus(200);
       }
 
-      if (payload.type === 'url_verification') {      
+      if (payload.type === 'url_verification') {
         res.send({ challenge: req.body.challenge });
       } else if (payload != null && payload.type === 'interactive_message' && payload.actions[0].value.indexOf('dialog_') !== -1) {
         // if it's the callback of a dialog button, then relay a dialog message
@@ -190,9 +190,9 @@ const Slack = new ChatExpress({
         this.receive({
           type: 'event',
           channel: _.isArray(payload.event.channel_ids) && !_.isEmpty(payload.event.channel_ids) ?
-            payload.event.channel_ids[0] : null,
+            payload.event.channel_ids[0] : (payload.event.channel ? payload.event.channel : null),
           eventPayload: _.omit(payload.event, 'type'),
-          eventType: payload.event.type        
+          eventType: payload.event.type
         });
         res.sendStatus(200);
       } else {
@@ -326,9 +326,9 @@ Slack.out('blocks', function(message) {
   const chatContext = message.chat();
   return new Promise(function(resolve, reject) {
     var client = options.client;
-    const payload = Object.assign({ 
-      channel: message.payload.chatId, 
-      blocks: message.payload.content 
+    const payload = Object.assign({
+      channel: message.payload.chatId,
+      blocks: message.payload.content
     }, slackExtensions);
     client.chat.postMessage(payload)
       .then(res => when(chatContext.set('messageId', res.ts)))
@@ -734,41 +734,41 @@ Slack.registerMessageType('message', 'Message', 'Send a plain text message');
 Slack.registerMessageType('blocks', 'Blocks', 'Send message as blocks (Slack Block Kit)');
 Slack.registerMessageType('response', 'Response', 'Dialog or Block Kit response');
 Slack.registerMessageType(
-  'video', 
-  'Video', 
-  'Send video message', 
+  'video',
+  'Video',
+  'Send video message',
   file => {
     if (!_.isEmpty(file.extension) && !videoExtensions.includes(file.extension)) {
       return `Unsupported file format for video node "${file.filename}", allowed formats: ${videoExtensions.join(', ')}`;
     }
     return null;
-  }  
+  }
 );
 Slack.registerMessageType(
-  'document', 
-  'Document', 
+  'document',
+  'Document',
   'Send a document or generic file',
   file => {
     if (!_.isEmpty(file.extension) && !documentExtensions.includes(file.extension)) {
       return `Unsupported file format for document node "${file.filename}", allowed formats: ${documentExtensions.join(', ')}`;
     }
     return null;
-  }  
+  }
 );
 Slack.registerMessageType(
-  'audio', 
-  'Audio', 
+  'audio',
+  'Audio',
   'Send an audio message',
   file => {
     if (!_.isEmpty(file.extension) && !audioExtensions.includes(file.extension)) {
       return `Unsupported file format for audio node "${file.filename}", allowed formats: ${audioExtensions.join(', ')}`;
     }
     return null;
-  }  
+  }
 );
 Slack.registerMessageType(
-  'photo', 
-  'Photo', 
+  'photo',
+  'Photo',
   'Send a photo message',
   file => {
     if (!_.isEmpty(file.extension) && !photoExtensions.includes(file.extension)) {

--- a/lib/platforms/slack.js
+++ b/lib/platforms/slack.js
@@ -29,6 +29,18 @@ const parseActions = actions => {
   return result;
 }
 
+const parseChannel = event => {
+  // not sure if channel_ids is still used in slack event payloads
+  if (_.isArray(event.channel_ids) && !_.isEmpty(event.channel_ids)) {
+    return event.channel_ids[0]
+  } else if (event.channel ) {
+    return event.channel
+  }
+  else {
+    return null
+  }
+}
+
 /*
 - Send a message, upload file: https://slackapi.github.io/node-slack-sdk/web_api#posting-a-message
 */
@@ -103,10 +115,6 @@ const Slack = new ChatExpress({
       res.send('ok');
     },
     '/redbot/slack': function(req, res) {
-
-
-
-
       let payload;
       if (_.isObject(req.body) && !_.isEmpty(req.body.type)) {
         payload = req.body;
@@ -189,8 +197,7 @@ const Slack = new ChatExpress({
       } else if (payload.type === 'event_callback') {
         this.receive({
           type: 'event',
-          channel: _.isArray(payload.event.channel_ids) && !_.isEmpty(payload.event.channel_ids) ?
-            payload.event.channel_ids[0] : (payload.event.channel ? payload.event.channel : null),
+          channel: parseChannel(payload.event),
           eventPayload: _.omit(payload.event, 'type'),
           eventType: payload.event.type
         });


### PR DESCRIPTION
Most of the slack event subscription payloads have their channel definition in `payload.event.channel`, this was missing in the current parsing flow. 

EDIT: I guess my editor trimmed some trailing whitespaces as well 😉 