### PR TITLE
Enhance regexp for commands

### DIFF
--- a/lib/helpers/regexps.js
+++ b/lib/helpers/regexps.js
@@ -35,7 +35,7 @@ module.exports = {
     if (_.isEmpty(commandName)) {
       return msg.match(/^\/.*/) != null;
     } else {
-      var matched = msg.match(/^\/(\w+)/);
+      var matched = msg.match(/^\/([\w-_]+)/);
       return matched != null && ('/' + matched[1]) === commandName;
     }
   }


### PR DESCRIPTION
Currently, the `isCommand` regexp only allows for commands containing `\w` characters. Chat commands could benefit from supporting dashes and underscores. The docs even suggest `/my-command` would work.