### PR TITLE
Don't use RED.settings.functionGlobalContext

### DIFF
--- a/lib/helpers/global-context-helper.js
+++ b/lib/helpers/global-context-helper.js
@@ -12,7 +12,7 @@ module.exports = function (RED) {
     init(store) {
       if (!isInitialised) {
         if (store) {
-          contextStore = store;
+          contextStore = { ...store };
         } else {
           contextStore = {
             get(name) {

--- a/lib/helpers/global-context-helper.js
+++ b/lib/helpers/global-context-helper.js
@@ -1,0 +1,42 @@
+var isInitialised = false;
+var contextStore = {};
+
+// adopted from: https://github.com/Steveorevo/node-red-contrib-actionflows/pull/20
+module.exports = function (RED) {
+  return {
+    /**
+     * Initialise the runtime global context functions and prepare access to global context via `contextStore`.
+     * If a context store is not provided, an internal store will be created instead to keep things running.
+     * @param {Object} [store] (optional) pass in the context store. Send `null` to use internal memory.
+     */
+    init(store) {
+      if (!isInitialised) {
+        if (store) {
+          contextStore = store;
+        } else {
+          contextStore = {
+            get(name) {
+              return RED.util.getObjectProperty(contextStore, name);
+            },
+            set(name, value) {
+              RED.util.setObjectProperty(contextStore, name, value, true);
+            },
+          };
+        }
+        isInitialised = true;
+      }
+    },
+    getContext() {
+      return contextStore;
+    },
+    get(name) {
+      return contextStore.get(name);
+    },
+    set(name, value) {
+      contextStore.set(name, value);
+    },
+    keys() {
+      return contextStore.keys();
+    },
+  };
+};

--- a/lib/sender-factory.js
+++ b/lib/sender-factory.js
@@ -36,7 +36,7 @@ const GenericBotNode = (
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var platformConfigs = globalcontexthelper.get(platform) || {};
+    var platformConfigs = globalContextHelper.get(platform) || {};
     var contextProviders = ContextProviders(RED);
 
     this.botname = n.botname;

--- a/lib/sender-factory.js
+++ b/lib/sender-factory.js
@@ -13,6 +13,7 @@ const {
   getTransport,
   isSimulator
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 const when = utils.when;
 const warn = clc.yellow;
@@ -27,13 +28,15 @@ const GenericBotNode = (
 ) => {
 
   return function(n) {
+    const globalContextHelper = GlobalContextHelper(RED);
 
     RED.nodes.createNode(this, n);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var platformConfigs = this.context().global.get(platform) || {};
+    var platformConfigs = globalcontexthelper.get(platform) || {};
     var contextProviders = ContextProviders(RED);
 
     this.botname = n.botname;
@@ -161,9 +164,11 @@ const GenericBotNode = (
 const GenericInNode = (platform, RED) => {
 
   return function(config) {
+    const globalContextHelper = GlobalContextHelper(RED);
 
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var global = this.context().global;
     var environment = global.environment === 'production' ? 'production' : 'development';
     var nodeGlobalKey = null;
@@ -179,11 +184,11 @@ const GenericInNode = (platform, RED) => {
         this.status({fill: 'green', shape: 'ring', text: 'connected'});
         nodeGlobalKey = platform + '_master_' + this.config.id.replace('.','_');
         var isMaster = false;
-        if (global.get(nodeGlobalKey) == null) {
+        if (globalContextHelper.get(nodeGlobalKey) == null) {
           isMaster = true;
-          global.set(nodeGlobalKey, node.id);
+          globalContextHelper.set(nodeGlobalKey, node.id);
           // store a list of chatbots and its references
-          global.set('chatbot_info_' + this.config.id.replace('.','_'), {
+          globalContextHelper.set('chatbot_info_' + this.config.id.replace('.','_'), {
             nodeId: node.id,
             transport: platform,
             name: this.config.botname
@@ -217,7 +222,7 @@ const GenericInNode = (platform, RED) => {
     }
 
     this.on('close', function (done) {
-      node.context().global.set(nodeGlobalKey, null);
+      globalContextHelper.set(nodeGlobalKey, null);
       if (node.chat != null) {
         node.chat.off('message');
       }
@@ -229,8 +234,11 @@ const GenericInNode = (platform, RED) => {
 const GenericOutNode = (platform, RED) => {
 
   return function(config) {
+    const globalContextHelper = GlobalContextHelper(RED);
+
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var global = this.context().global;
     var environment = global.environment === 'production' ? 'production' : 'development';
 

--- a/lib/sender-factory.js
+++ b/lib/sender-factory.js
@@ -33,7 +33,7 @@ const GenericBotNode = (
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var platformConfigs = RED.settings.functionGlobalContext.get(platform) || {};
+    var platformConfigs = this.context().global.get(platform) || {};
     var contextProviders = ContextProviders(RED);
 
     this.botname = n.botname;

--- a/nodes/chatbot-alexa-card.js
+++ b/nodes/chatbot-alexa-card.js
@@ -8,13 +8,16 @@ const {
   extractValue,
   append 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotCard(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.cardType = config.cardType;
     this.cardType = config.cardType;
     this.text = config.text;

--- a/nodes/chatbot-alexa-directive.js
+++ b/nodes/chatbot-alexa-directive.js
@@ -8,13 +8,16 @@ const {
   extractValue,
   append 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotAlexaDirective(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.directiveType = config.directiveType;
     this.slot = config.slot;
 

--- a/nodes/chatbot-alexa-receive.js
+++ b/nodes/chatbot-alexa-receive.js
@@ -33,7 +33,7 @@ module.exports = function(RED) {
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var alexaConfigs = RED.settings.functionGlobalContext.get('alexa') || {};
+    var alexaConfigs = this.context().global.get('alexa') || {};
 
     this.botname = n.botname;
     this.store = n.store;

--- a/nodes/chatbot-alexa-receive.js
+++ b/nodes/chatbot-alexa-receive.js
@@ -8,6 +8,7 @@ const lcd = require('../lib/helpers/lcd');
 const prettyjson = require('prettyjson');
 const validators = require('../lib/helpers/validators');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 const when = utils.when;
 const warn = clc.yellow;
@@ -15,6 +16,7 @@ const green = clc.green;
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   // register Alexa server
   if (RED.redbot == null) {
@@ -30,10 +32,11 @@ module.exports = function(RED) {
   function AlexaBotNode(n) {
     RED.nodes.createNode(this, n);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var alexaConfigs = this.context().global.get('alexa') || {};
+    var alexaConfigs = globalContextHelper.get('alexa') || {};
 
     this.botname = n.botname;
     this.store = n.store;
@@ -165,6 +168,7 @@ module.exports = function(RED) {
 
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var global = this.context().global;
     var environment = global.environment === 'production' ? 'production' : 'development';
     var nodeGlobalKey = null;
@@ -180,9 +184,9 @@ module.exports = function(RED) {
         this.status({fill: 'green', shape: 'ring', text: 'connected'});
         nodeGlobalKey = 'alexa_master_' + this.config.id.replace('.','_');
         var isMaster = false;
-        if (global.get(nodeGlobalKey) == null) {
+        if (globalContextHelper.get(nodeGlobalKey) == null) {
           isMaster = true;
-          global.set(nodeGlobalKey, node.id);
+          globalContextHelper.set(nodeGlobalKey, node.id);
         }
         node.chat.on('message', function (message) {
           var context = message.chat();
@@ -212,7 +216,7 @@ module.exports = function(RED) {
     }
 
     this.on('close', function (done) {
-      node.context().global.set(nodeGlobalKey, null);
+      globalContextHelper.set(nodeGlobalKey, null);
       if (node.chat != null) {
         node.chat.off('message');
       }
@@ -224,6 +228,7 @@ module.exports = function(RED) {
   function AlexaOutNode(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var global = this.context().global;
     var environment = global.environment === 'production' ? 'production' : 'development';
 

--- a/nodes/chatbot-alexa-speech.js
+++ b/nodes/chatbot-alexa-speech.js
@@ -9,9 +9,11 @@ const {
   extractValue,
   append 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   const txType = {
     plainText: 'PlainText',
@@ -26,6 +28,7 @@ module.exports = function(RED) {
   function ChatBotAlexaSpeech(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.speechType = config.speechType;
     this.text = config.text;
     this.ssml = config.ssml;

--- a/nodes/chatbot-analytics.js
+++ b/nodes/chatbot-analytics.js
@@ -2,13 +2,16 @@ const RegisterType = require('../lib/node-installer');
 const analytics = {
   dashbot: require('../lib/analytics/dashbot')
 };
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotAnalytics(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.platform = config.platform;
     this.token = config.token;
 

--- a/nodes/chatbot-animation.js
+++ b/nodes/chatbot-animation.js
@@ -13,13 +13,16 @@ const {
   getTransport, 
   extractValue 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotAnimation(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.animation = config.animation;
     this.name = config.name;
     this.caption = config.caption;

--- a/nodes/chatbot-ask.js
+++ b/nodes/chatbot-ask.js
@@ -3,13 +3,16 @@ const MessageTemplate = require('../lib/message-template-async');
 const emoji = require('node-emoji');
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotAsk(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.buttons = config.buttons;
     this.message = config.message;
     this.inline = config.inline;

--- a/nodes/chatbot-audio.js
+++ b/nodes/chatbot-audio.js
@@ -13,13 +13,16 @@ const {
   getTransport, 
   extractValue 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotAudio(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.audio = config.audio;
     this.duration = config.duration;
     this.caption = config.caption;

--- a/nodes/chatbot-authorized.js
+++ b/nodes/chatbot-authorized.js
@@ -1,13 +1,16 @@
 const utils = require('../lib/helpers/utils');
 const when = utils.when;
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotAuthorized(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
 
     this.on('input', function(msg) {
       var chatContext = msg.chat();

--- a/nodes/chatbot-broadcast.js
+++ b/nodes/chatbot-broadcast.js
@@ -1,13 +1,16 @@
 const _ = require('underscore');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotBroadcast(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var global = this.context().global;
     var environment = global.environment === 'production' ? 'production' : 'development';
 

--- a/nodes/chatbot-command.js
+++ b/nodes/chatbot-command.js
@@ -1,12 +1,15 @@
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotCommand(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.command = config.command;
 
     this.on('input', function(msg) {

--- a/nodes/chatbot-context.js
+++ b/nodes/chatbot-context.js
@@ -3,13 +3,16 @@ const _ = require('underscore');
 const when = utils.when;
 const RegisterType = require('../lib/node-installer');
 const { isValidMessage } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotContext(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.command = config.command;
     this.fieldValue = config.fieldValue;
     this.fieldType = config.fieldType;

--- a/nodes/chatbot-conversation.js
+++ b/nodes/chatbot-conversation.js
@@ -1,5 +1,6 @@
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 const { UniversalPlatform, ContextProviders } = require('chat-platform');
 
 const isEmpty = value => _.isEmpty(value) && !_.isNumber(value);
@@ -10,10 +11,12 @@ const {
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotConversation(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     const global = this.context().global;
 
     this.chatId = config.chatId;

--- a/nodes/chatbot-debug.js
+++ b/nodes/chatbot-debug.js
@@ -3,13 +3,16 @@ const utils = require('../lib/helpers/utils');
 const lcd = require('../lib/helpers/lcd');
 const when = utils.when;
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotDebug(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.chatId = config.chatId;
 
     this.on('input', function(msg) {

--- a/nodes/chatbot-dialog.js
+++ b/nodes/chatbot-dialog.js
@@ -1,13 +1,16 @@
 const utils = require('../lib/helpers/utils');
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotDialog(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.name = config.name;
     this.elements = _.isArray(config.elements) && !_.isEmpty(config.elements) ? config.elements : null;
     this.title = config.title;

--- a/nodes/chatbot-dialogflow.js
+++ b/nodes/chatbot-dialogflow.js
@@ -4,6 +4,7 @@ const lcd = require('../lib/helpers/lcd');
 const dialogflow = require('dialogflow');
 const when = utils.when;
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 function parseValue(value) {
   if (value.kind === 'stringValue') {
@@ -37,10 +38,12 @@ function parseFields(fields) {
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotDialogflow(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     node.dialogflow = config.dialogflow;
     node.language = config.language;
     node.debug = config.debug;
@@ -163,6 +166,7 @@ module.exports = function(RED) {
 
   function DialogflowToken(n) {
     RED.nodes.createNode(this, n);
+    globalContextHelper.init(this.context().global);
   }
 
   registerType('chatbot-dialogflow-token', DialogflowToken, {

--- a/nodes/chatbot-document.js
+++ b/nodes/chatbot-document.js
@@ -15,14 +15,17 @@ const {
   extractValue,
   appendPayload
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotDocument(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.filename = config.filename;
     this.document = config.document;
     this.name = config.name;

--- a/nodes/chatbot-extend.js
+++ b/nodes/chatbot-extend.js
@@ -1,10 +1,13 @@
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotExtend(config) {
     RED.nodes.createNode(this, config);
+    globalContextHelper.init(this.context().global);
     this.codeJs = config.codeJs;
   }
   registerType('chatbot-extend', ChatBotExtend);

--- a/nodes/chatbot-generic-template.js
+++ b/nodes/chatbot-generic-template.js
@@ -10,13 +10,16 @@ const {
   getTransport,
   extractValue
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotGenericTemplate(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.name = config.name;
     this.buttons = config.buttons;
     this.title = config.title;

--- a/nodes/chatbot-image.js
+++ b/nodes/chatbot-image.js
@@ -14,13 +14,16 @@ const {
   extractValue,
   appendPayload
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotImage(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.image = config.image;
     this.name = config.name;
     this.caption = config.caption;

--- a/nodes/chatbot-inline-buttons.js
+++ b/nodes/chatbot-inline-buttons.js
@@ -11,16 +11,19 @@ const {
   appendPayload,
   getTransport
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 require('../lib/platforms/telegram');
 require('../lib/platforms/facebook/facebook');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotInlineButtons(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.name = config.name;
     this.buttons = config.buttons;
     this.message = config.message;

--- a/nodes/chatbot-inline-query.js
+++ b/nodes/chatbot-inline-query.js
@@ -1,12 +1,15 @@
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotInlineQuery(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     node.personal = config.personal;
     node.caching = config.caching;
     // just store the information

--- a/nodes/chatbot-invoice-shipping.js
+++ b/nodes/chatbot-invoice-shipping.js
@@ -2,13 +2,16 @@ const MessageTemplate = require('../lib/message-template-async');
 const utils = require('../lib/helpers/utils');
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotInvoiceShipping(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.name = config.name;
     this.shippingOptions = config.shippingOptions;
     this.transports = ['telegram'];

--- a/nodes/chatbot-invoice.js
+++ b/nodes/chatbot-invoice.js
@@ -5,13 +5,16 @@ const _ = require('underscore');
 const validators = require('../lib/helpers/validators');
 const RegisterType = require('../lib/node-installer');
 const lcd = require('../lib/helpers/lcd');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotInvoice(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.name = config.name;
     this.title = config.title;
     this.description = config.description;

--- a/nodes/chatbot-language.js
+++ b/nodes/chatbot-language.js
@@ -4,13 +4,16 @@ const { Language } = require('node-nlp');
 const RegisterType = require('../lib/node-installer');
 const { isCommand } = require('../lib/helpers/regexps');
 const { isValidMessage } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotLanguage(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
 
     this.on('input', async function(msg, send, done) {
       // send/done compatibility for node-red < 1.0

--- a/nodes/chatbot-location.js
+++ b/nodes/chatbot-location.js
@@ -11,13 +11,16 @@ const {
   appendPayload
 } = require('../lib/helpers/utils');
 const MessageTemplate = require('../lib/message-template-async');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotLocation(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.latitude = config.latitude;
     this.longitude = config.longitude;
     this.place = config.place;

--- a/nodes/chatbot-log.js
+++ b/nodes/chatbot-log.js
@@ -1,15 +1,18 @@
 const ChatLog = require('../lib/chat-log.js');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 const when = utils.when;
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotLog(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
 
     this.on('input', function(msg) {
 

--- a/nodes/chatbot-message.js
+++ b/nodes/chatbot-message.js
@@ -12,13 +12,16 @@ const {
   appendPayload
 } = require('../lib/helpers/utils');
 const MessageTemplate = require('../lib/message-template-async');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotMessage(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.message = config.message;
     this.parse_mode = config.parse_mode;
     this.language = config.language;

--- a/nodes/chatbot-messenger-menu.js
+++ b/nodes/chatbot-messenger-menu.js
@@ -1,13 +1,16 @@
 const utils = require('../lib/helpers/utils');
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotMessengerMenu(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.items = config.items;
     this.command = config.command;
     this.composerInputDisabled = config.composerInputDisabled;

--- a/nodes/chatbot-messenger-template.js
+++ b/nodes/chatbot-messenger-template.js
@@ -10,13 +10,16 @@ const {
   getTransport,
   extractValue
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotMessengerTemplate(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.name = config.name;
     this.templateType = config.templateType;
     this.text = config.text;

--- a/nodes/chatbot-msteams-receive.js
+++ b/nodes/chatbot-msteams-receive.js
@@ -25,7 +25,7 @@ module.exports = function(RED) {
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var msteamsConfigs = RED.settings.functionGlobalContext.get('msteams') || {};
+    var msteamsConfigs = this.context().global.get('msteams') || {};
 
     this.botname = n.botname;
     this.store = n.store;

--- a/nodes/chatbot-nlp-entity.js
+++ b/nodes/chatbot-nlp-entity.js
@@ -1,13 +1,16 @@
 const _ = require('underscore');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotNLPEntity(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
 
     this.entities = config.entities;
     this.name = config.name;

--- a/nodes/chatbot-nlp-intent.js
+++ b/nodes/chatbot-nlp-intent.js
@@ -1,13 +1,16 @@
 const _ = require('underscore');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotNLPIntent(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
 
     this.utterances = config.utterances;
     this.intent = config.intent;

--- a/nodes/chatbot-nlp-load.js
+++ b/nodes/chatbot-nlp-load.js
@@ -1,15 +1,18 @@
 const _ = require('underscore');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 const fs = require('fs');
 const { NlpManager } = require('node-nlp');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotNLPLoad(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.filename = config.filename;
 
     this.on('input', function(msg, send, done) {
@@ -31,7 +34,7 @@ module.exports = function(RED) {
         const manager = new NlpManager();
         manager.import(json);
         // store globally
-        global.set('nlp_' + (!_.isEmpty(name) ? name : 'default'), manager);
+        globalContextHelper.set('nlp_' + (!_.isEmpty(name) ? name : 'default'), manager);
         // pass thru
         send({ ...msg, payload: manager });
         done();

--- a/nodes/chatbot-nlp-save.js
+++ b/nodes/chatbot-nlp-save.js
@@ -1,14 +1,17 @@
 const _ = require('underscore');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 const fs = require('fs');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotNLPSave(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.filename = config.filename;
 
     this.on('input', function(msg, send, done) {

--- a/nodes/chatbot-nlp-train.js
+++ b/nodes/chatbot-nlp-train.js
@@ -4,13 +4,16 @@ const { NlpManager } = require('node-nlp');
 const lcd = require('../lib/helpers/lcd');
 const RegisterType = require('../lib/node-installer');
 const { extractValue } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotNLPjs(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
 
     this.name = config.name;
     this.debug = config.debug;
@@ -83,7 +86,7 @@ module.exports = function(RED) {
       await manager.train();
       manager.save();
       // store globally
-      global.set('nlp_' + (!_.isEmpty(name) ? name : 'default'), manager);
+      globalContextHelper.set('nlp_' + (!_.isEmpty(name) ? name : 'default'), manager);
 
       send({...msg, payload: manager });
       done();

--- a/nodes/chatbot-nlp.js
+++ b/nodes/chatbot-nlp.js
@@ -7,13 +7,16 @@ const RegisterType = require('../lib/node-installer');
 const MessageTemplate = require('../lib/message-template-async');
 const { variable: isVariable } = require('../lib/helpers/validators');
 const { isValidMessage, extractValue, isCommand } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotNLPjs(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
 
     this.name = config.name;
     this.debug = config.debug;
@@ -62,7 +65,7 @@ module.exports = function(RED) {
       // https://github.com/axa-group/nlp.js/blob/master/docs/v3/slot-filling.md#entities-with-the-same-name
 
       // get the right nlp model
-      const manager = global.get('nlp_' + (!_.isEmpty(name) ? name : 'default'));
+      const manager = globalContextHelper.get('nlp_' + (!_.isEmpty(name) ? name : 'default'));
 
       // check if string
       if (!_.isString(content)) {

--- a/nodes/chatbot-params.js
+++ b/nodes/chatbot-params.js
@@ -6,13 +6,16 @@ const {
   extractValue
 } = require('../lib/helpers/utils');
 const MessageTemplate = require('../lib/message-template-async');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotParams(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.params = config.params;
 
     this.on('input', function(msg, send, done) {

--- a/nodes/chatbot-parse.js
+++ b/nodes/chatbot-parse.js
@@ -3,11 +3,13 @@ const nlp = require('compromise');
 const moment = require('moment');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 const cloneMessage = utils.cloneMessage;
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   var yesWords = ['yes', 'on', 'true', 'yeah', 'ya', 'si'];
   var noWords = ['no', 'off', 'false', 'nei', 'nein'];
@@ -21,6 +23,7 @@ module.exports = function(RED) {
   function ChatBotParse(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.parseType = config.parseType;
     this.parseVariable = config.parseVariable;
 

--- a/nodes/chatbot-pop-message.js
+++ b/nodes/chatbot-pop-message.js
@@ -1,11 +1,14 @@
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotPopMessage(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
 
     this.on('input', function(msg, send, done) {
       // send/done compatibility for node-red < 1.0

--- a/nodes/chatbot-qrcode.js
+++ b/nodes/chatbot-qrcode.js
@@ -2,13 +2,16 @@ const qr = require('qr-image');
 const MessageTemplate = require('../lib/message-template-async');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotQRCode(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.message = config.message;
 
     this.on('input', function(msg) {

--- a/nodes/chatbot-quick-replies.js
+++ b/nodes/chatbot-quick-replies.js
@@ -9,13 +9,16 @@ const {
   getTransport, 
   extractValue 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotQuickReplies(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.buttons = config.buttons;
     this.message = config.message;
     this.transports = ['facebook'];

--- a/nodes/chatbot-request.js
+++ b/nodes/chatbot-request.js
@@ -2,13 +2,16 @@ const MessageTemplate = require('../lib/message-template-async');
 const emoji = require('node-emoji');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotRequest(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.message = config.message;
     this.buttonLabel = config.buttonLabel;
     this.requestType = config.requestType;

--- a/nodes/chatbot-rivescript.js
+++ b/nodes/chatbot-rivescript.js
@@ -5,6 +5,7 @@ const lcd = require('../lib/helpers/lcd');
 const helpers = require('../lib/helpers/regexps');
 const { when, getChatId, extractValue } = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 const getOrCreateBot = ({ script, scriptFile, context, debug }) => {
   return new Promise((resolve, reject) => {
@@ -48,10 +49,12 @@ const getOrCreateBot = ({ script, scriptFile, context, debug }) => {
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotRivescript(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.script = config.script;
     this.debug = config.debug;
     this.scriptFile = config.scriptFile;

--- a/nodes/chatbot-routee-receive.js
+++ b/nodes/chatbot-routee-receive.js
@@ -36,7 +36,7 @@ module.exports = function(RED) {
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var routeeConfigs = RED.settings.functionGlobalContext.get('routee') || {};
+    var routeeConfigs = this.context().global.get('routee') || {};
 
     this.botname = n.botname;
     this.store = n.store;

--- a/nodes/chatbot-rules.js
+++ b/nodes/chatbot-rules.js
@@ -2,6 +2,7 @@ const utils = require('../lib/helpers/utils');
 const helpers = require('../lib/helpers/regexps');
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 const when = utils.when;
 
@@ -436,10 +437,12 @@ function executeRules(rules, message, global, current) {
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotRules(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     var global = this.context().global;
     node.rules = config.rules;
 

--- a/nodes/chatbot-slack-blocks.js
+++ b/nodes/chatbot-slack-blocks.js
@@ -9,16 +9,19 @@ const {
   extractValue
 } = require('../lib/helpers/utils');
 const MessageTemplate = require('../lib/message-template-async');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 require('../lib/platforms/telegram');
 require('../lib/platforms/slack/index');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotSlackBlocks(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.blocks = config.blocks;
 
     this.on('input', function(msg, send, done) {

--- a/nodes/chatbot-sticker.js
+++ b/nodes/chatbot-sticker.js
@@ -13,13 +13,16 @@ const {
   getTransport,
   extractValue
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotSticker(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.sticker = config.sticker;
     this.name = config.name;
     this.caption = config.caption;

--- a/nodes/chatbot-support-table.js
+++ b/nodes/chatbot-support-table.js
@@ -1,11 +1,14 @@
 const { ChatExpress } = require('chat-platform');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotSupportTable(config) {
     RED.nodes.createNode(this, config);
+    globalContextHelper.init(this.context().global);
     this.on('input', function() {
       ChatExpress.showCompatibilityChart();
     });

--- a/nodes/chatbot-telegram-menu.js
+++ b/nodes/chatbot-telegram-menu.js
@@ -1,12 +1,15 @@
 const _ = require('underscore');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotTelegramrMenu(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.bot = config.bot;
     this.items = config.items;
 

--- a/nodes/chatbot-topic.js
+++ b/nodes/chatbot-topic.js
@@ -1,12 +1,15 @@
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotTopic(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
 
     node.rules = config.rules;
 

--- a/nodes/chatbot-transport.js
+++ b/nodes/chatbot-transport.js
@@ -1,11 +1,14 @@
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotCommand(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
 
     node.rules = config.rules;
 

--- a/nodes/chatbot-universal-receive.js
+++ b/nodes/chatbot-universal-receive.js
@@ -33,7 +33,7 @@ module.exports = function(RED) {
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var universalConfigs = RED.settings.functionGlobalContext.get('universal') || {};
+    var universalConfigs = this.context().global.get('universal') || {};
 
     this.botname = n.botname;
     this.store = n.store;

--- a/nodes/chatbot-viber-receive.js
+++ b/nodes/chatbot-viber-receive.js
@@ -34,7 +34,7 @@ module.exports = function(RED) {
     var environment = this.context().global.environment === 'production' ? 'production' : 'development';
     var isUsed = utils.isUsed(RED, node.id);
     var startNode = utils.isUsedInEnvironment(RED, node.id, environment);
-    var viberConfigs = RED.settings.functionGlobalContext.get('viber') || {};
+    var viberConfigs = this.context().global.get('viber') || {};
 
     this.botname = n.botname;
     this.store = n.store;

--- a/nodes/chatbot-video.js
+++ b/nodes/chatbot-video.js
@@ -13,13 +13,16 @@ const {
   getTransport, 
   extractValue 
 } = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotVideo(config) {
     RED.nodes.createNode(this, config);
     const node = this;
+    globalContextHelper.init(this.context().global);
     this.filename = config.filename;
     this.video = config.video;
     this.name = config.name;

--- a/nodes/chatbot-voice.js
+++ b/nodes/chatbot-voice.js
@@ -9,13 +9,16 @@ const {
   extractValue 
 } = require('../lib/helpers/utils');
 const MessageTemplate = require('../lib/message-template-async');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotVoice(config) {
     RED.nodes.createNode(this, config);
     var node = this;
+    globalContextHelper.init(this.context().global);
     this.message = config.message;
     this.language = config.language;
 

--- a/nodes/chatbot-waiting.js
+++ b/nodes/chatbot-waiting.js
@@ -1,12 +1,15 @@
 const _ = require('underscore');
 const utils = require('../lib/helpers/utils');
 const RegisterType = require('../lib/node-installer');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
 
 module.exports = function(RED) {
   const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
 
   function ChatBotWaiting(config) {
     RED.nodes.createNode(this, config);
+    globalContextHelper.init(this.context().global);
 
     this.waitingType = config.waitingType;
     this.transports = ['telegram', 'slack', 'facebook'];


### PR DESCRIPTION
This fixes guidone#520 partially. If you make a HTTP call to `/redbot/globals` this will still not work, but I do not know how to adjust this. Maybe someone more experienced can adopt this part (maybe inspired from https://github.com/Steveorevo/node-red-contrib-actionflows/pull/20).

This PR at least fixes my usage with Telegram in pulling mode.

I'm new to node-red node development and could only fix it in my scenario. Hope this helps anyone. If anyone have changes to anything, you are very much appreciated to modify this PR 😄.

There are several more mentions of [`functionGlobalContext`](https://github.com/guidone/node-red-contrib-chatbot/search?q=functionGlobalContext) also in html files and the Wiki. These might also be needed to update but I also don't know how this is used in production so I couldn't test it.

Edited:

### If someone would like to try this out ...

In your `.node-red` directory (usually `cd ~/.node-red`) run the below command to install directly from GitHub:

```
npm i guidone/node-red-contrib-chatbot#pull/522/head
```

NOTE: This is only temporary and may change / disappear - the real solution is for a fix to be published to NPM