### PR TITLE
Update slack webhooks urls

### DIFF
--- a/lib/platforms/slack/index.js
+++ b/lib/platforms/slack/index.js
@@ -304,17 +304,17 @@ const Slack = new ChatExpress({
       // eslint-disable-next-line no-console
       console.log(lcd.grey('------ WebHooks for SLACK ----------------'));
       // eslint-disable-next-line no-console
-      console.log(lcd.green(`http://localhost:${serverPort}/events`)
+      console.log(lcd.green(`http://localhost:${serverPort}/slack/events`)
         + lcd.grey(' - ')
         + lcd.white('Callback for events')
       );
       // eslint-disable-next-line no-console
-      console.log(lcd.green(`http://localhost:${serverPort}/interactions`)
+      console.log(lcd.green(`http://localhost:${serverPort}/slack/interactions`)
         + lcd.grey(' - ')
         + lcd.white('Callback for interactions (postback, dialogs, etc)')
       );
       // eslint-disable-next-line no-console
-      console.log(lcd.green(`http://localhost:${serverPort}/commands`)
+      console.log(lcd.green(`http://localhost:${serverPort}/slack/commands`)
         + lcd.grey(' - ')
         + lcd.white('Callback for commands')
       );


### PR DESCRIPTION
The endpoints shown in logs are not valid. This PR adds "/slack/" part to them to make them correct