### PR TITLE
Make possible to send images to Twilio with MediaURL

### DIFF
--- a/lib/platforms/twilio/twilio.js
+++ b/lib/platforms/twilio/twilio.js
@@ -55,6 +55,26 @@ const Twilio = new ChatExpress({
   }
 });
 
+Twilio.out('photo-url', async function(message) {
+  const options = this.getOptions();
+  const context = message.chat();
+  const client = message.client();
+  const fromNumber = options.fromNumber;
+
+  const response = await client.messages
+    .create({
+      body: message.payload.caption,
+      mediaUrl: message.payload.content,
+      from: fixNumber(fromNumber),
+      to: fixNumber(message.payload.chatId)
+    });
+
+  await when(context.set('messageId', response.sid));
+
+  return setMessageId(message, response.sid);
+
+})
+
 Twilio.out('message', async function(message) {
   const options = this.getOptions();
   const context = message.chat();
@@ -138,5 +158,6 @@ Twilio.in('*', function(message) {
 });
 
 Twilio.registerMessageType('message', 'Message', 'Send a plain text message');
+Twilio.registerMessageType('photo-url', 'PhotoUrl', 'Send a photo message');
 
 module.exports = Twilio;

--- a/nodes/chatbot-image-url.html
+++ b/nodes/chatbot-image-url.html
@@ -1,0 +1,80 @@
+<script type="text/javascript">
+  $.RedBot.registerType('chatbot-image-url', {
+    category: $.RedBot.config.name,
+    color: '#FFCC66',
+    defaults: {
+      name: {
+        value: ''
+      },
+      image: {
+        value: ''
+      },
+      caption: {
+        value: '',
+        required: false
+      }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'chatbot-image.png',
+    paletteLabel: 'Image URL',
+    label: function() {
+      return this.name || 'Image URL';
+    },
+    oneditprepare: function() {
+      $.RedBot.fetchPlatforms()
+        .done(function(platforms) {
+          $('#dialog-form').RB_Platforms();
+        });
+    }
+  });
+</script>
+
+<script type="text/x-red" data-template-name="chatbot-image-url">
+<div class="form-row">
+  <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+  <input type="text" id="node-input-name" placeholder="Name">
+</div>
+<div class="form-row">
+  <label for="node-input-image">Image</label>
+  <input type="text" id="node-input-image" placeholder="Image URL">
+</div>
+<div class="form-row">
+  <label for="node-input-caption">Caption</label>
+  <input type="text" id="node-input-caption" placeholder="Caption">
+  <div class="redbot-platforms twilio"/>
+</div>
+
+</script>
+
+<script type="text/x-red" data-help-name="chatbot-image-url"><p>The <code>Image URL node</code> sends an URL of the image to the chatbot for the channels that does not support sending image in binary (e.g. Twilio)<p>
+<p>To programmatically send an image with a <code>Function node</code></p>
+<pre><code class="language-javascript">msg.payload = &#39;http://www.my_host.com/my_dir/my_image.png&#39;;
+</code></pre>
+<p>or</p>
+<pre><code class="language-javascript">msg.payload = {
+  caption: &#39;I am the caption&#39;,
+  image: &#39;http://www.my_host.com/my_dir/my_image.png&#39;
+};
+</code></pre>
+<p>Available parameters for the <code>msg.payload</code></p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>image</td>
+<td>string</td>
+<td>The image string should be URL (context variables can be used)</td>
+</tr>
+<tr>
+<td>caption</td>
+<td>string</td>
+<td>Caption of the image</td>
+</tr>
+</tbody></table>
+</script>

--- a/nodes/chatbot-image-url.js
+++ b/nodes/chatbot-image-url.js
@@ -1,0 +1,71 @@
+const _ = require('underscore');
+
+const MessageTemplate = require('../lib/message-template-async');
+const fetchers = require('../lib/helpers/fetchers-obj');
+const validators = require('../lib/helpers/validators');
+const { ChatExpress } = require('chat-platform');
+const RegisterType = require('../lib/node-installer');
+const {
+  enrichFilePayload,
+  isValidMessage,
+  getChatId,
+  getMessageId,
+  getTransport,
+  extractValue,
+  appendPayload
+} = require('../lib/helpers/utils');
+const GlobalContextHelper = require('../lib/helpers/global-context-helper');
+
+module.exports = function (RED) {
+  const registerType = RegisterType(RED);
+  const globalContextHelper = GlobalContextHelper(RED);
+
+  function ChatBotImageURL(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+    globalContextHelper.init(this.context().global);
+    this.image = config.image;
+    this.name = config.name;
+    this.caption = config.caption;
+    this.filename = config.filename; // for retrocompatibility
+
+    this.on('input', function (msg, send, done) {
+      // send/done compatibility for node-red < 1.0
+      send = send || function () { node.send.apply(node, arguments) };
+      done = done || function (error) { node.error.call(node, error, msg) };
+      const sendPayload = appendPayload(send, msg);
+      // check if valid message
+      if (!isValidMessage(msg, node)) {
+        return;
+      }
+      // get config
+      const chatId = getChatId(msg);
+      const messageId = getMessageId(msg);
+      const transport = getTransport(msg);
+      const template = MessageTemplate(msg, node);
+      // check transport compatibility
+      if (!ChatExpress.isSupported(transport, 'photo-url')) {
+        done(`Node "photo-url" is not supported by ${transport} transport`);
+        return;
+      }
+
+      let content = extractValue('string', 'image', node, msg)
+        || extractValue('stringWithVariables', 'image', node, msg)
+      let caption = extractValue('string', 'caption', node, msg, false);
+
+      template({ content, caption })
+        .then(({ content, caption }) => {
+          sendPayload({
+            type: 'photo-url',
+            content: content,
+            caption: caption,
+            chatId: chatId,
+            messageId: messageId,
+            inbound: false
+          });
+        });
+    });
+  }
+
+  registerType('chatbot-image-url', ChatBotImageURL);
+};

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "chatbot-document": "./nodes/chatbot-document.js",
       "chatbot-video": "./nodes/chatbot-video.js",
       "chatbot-image": "./nodes/chatbot-image.js",
+      "chatbot-image-url": "./nodes/chatbot-image-url.js",
       "chatbot-sticker": "./nodes/chatbot-sticker.js",
       "chatbot-animation": "./nodes/chatbot-animation.js",
       "chatbot-audio": "./nodes/chatbot-audio.js",


### PR DESCRIPTION
In this PR, I have added a new node called "Image URL" that allows users to send images by URL for the Twilio channel by utilizing the MediaURL field. Twilio does not support sending images in binary, so using a URL is the recommended method for sending images through this channel.

